### PR TITLE
SCTP ppid can be specified in sendmsg() and send_to().

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,13 @@ impl SctpStream {
 
 	/// Send bytes on the specified SCTP stream. On success, returns the
 	/// quantity of bytes read
-	pub fn sendmsg(&self, msg: &[u8], ppid: u32, stream: u16) -> Result<usize> {
+	pub fn sendmsg(&self, msg: &[u8], stream: u16) -> Result<usize> {
+		return self.0.sendmsg::<SocketAddr>(msg, None, 0, stream, 0);
+	}
+
+	/// Send bytes on the specified SCTP stream. On success, returns the
+	/// quantity of bytes read
+	pub fn sendmsg_ppid(&self, msg: &[u8], ppid: u32, stream: u16) -> Result<usize> {
 		return self.0.sendmsg::<SocketAddr>(msg, None, ppid, stream, 0);
 	}
 
@@ -233,8 +239,8 @@ impl SctpEndpoint {
 
 	/// Send data in Sctp style, to the provided address on the stream `stream`.
 	/// On success, returns the quantity on bytes sent
-	pub fn send_to<A: ToSocketAddrs>(&self, msg: &mut [u8], address: A, ppid: u32, stream: u16) -> Result<usize> {
-		return self.0.sendmsg(msg, Some(address), ppid, stream, 0);
+	pub fn send_to<A: ToSocketAddrs>(&self, msg: &mut [u8], address: A, stream: u16) -> Result<usize> {
+		return self.0.sendmsg(msg, Some(address), 0, stream, 0);
 	}
 
 	/// Get local socket addresses to which this socket is bound

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl SctpStream {
 
 	/// Send bytes on the specified SCTP stream. On success, returns the
 	/// quantity of bytes read
-	pub fn sendmsg(&self, msg: &[u8], ppid: u64, stream: u16) -> Result<usize> {
+	pub fn sendmsg(&self, msg: &[u8], ppid: u32, stream: u16) -> Result<usize> {
 		return self.0.sendmsg::<SocketAddr>(msg, None, ppid, stream, 0);
 	}
 
@@ -233,7 +233,7 @@ impl SctpEndpoint {
 
 	/// Send data in Sctp style, to the provided address on the stream `stream`.
 	/// On success, returns the quantity on bytes sent
-	pub fn send_to<A: ToSocketAddrs>(&self, msg: &mut [u8], address: A, ppid: u64, stream: u16) -> Result<usize> {
+	pub fn send_to<A: ToSocketAddrs>(&self, msg: &mut [u8], address: A, ppid: u32, stream: u16) -> Result<usize> {
 		return self.0.sendmsg(msg, Some(address), ppid, stream, 0);
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@ impl SctpStream {
 
 	/// Send bytes on the specified SCTP stream. On success, returns the
 	/// quantity of bytes read
-	pub fn sendmsg(&self, msg: &[u8], stream: u16) -> Result<usize> {
-		return self.0.sendmsg::<SocketAddr>(msg, None, stream, 0);
+	pub fn sendmsg(&self, msg: &[u8], ppid: u64, stream: u16) -> Result<usize> {
+		return self.0.sendmsg::<SocketAddr>(msg, None, ppid, stream, 0);
 	}
 
 	/// Read bytes. On success, return a tuple with the quantity of
@@ -233,8 +233,8 @@ impl SctpEndpoint {
 
 	/// Send data in Sctp style, to the provided address on the stream `stream`.
 	/// On success, returns the quantity on bytes sent
-	pub fn send_to<A: ToSocketAddrs>(&self, msg: &mut [u8], address: A, stream: u16) -> Result<usize> {
-		return self.0.sendmsg(msg, Some(address), stream, 0);
+	pub fn send_to<A: ToSocketAddrs>(&self, msg: &mut [u8], address: A, ppid: u64, stream: u16) -> Result<usize> {
+		return self.0.sendmsg(msg, Some(address), ppid, stream, 0);
 	}
 
 	/// Get local socket addresses to which this socket is bound

--- a/src/sctpsock.rs
+++ b/src/sctpsock.rs
@@ -358,7 +358,7 @@ impl SctpSocket {
 
 	/// Send data in Sctp style, to the provided address (may be `None` if the socket is connected), on the stream `stream`, with the TTL `ttl`.
 	/// On success, returns the quantity on bytes sent
-	pub fn sendmsg<A: ToSocketAddrs>(&self, msg: &[u8], address: Option<A>, ppid: u64, stream: u16, ttl: libc::c_ulong) -> Result<usize> {
+	pub fn sendmsg<A: ToSocketAddrs>(&self, msg: &[u8], address: Option<A>, ppid: u32, stream: u16, ttl: libc::c_ulong) -> Result<usize> {
 		let len = msg.len() as libc::size_t;
 		let (raw_addr, addr_len) = match address {
 			Some(a) => {
@@ -367,8 +367,9 @@ impl SctpSocket {
 			},
 			None => (std::ptr::null_mut(), 0)
 		};
+    let ppid = ppid.to_be();
 		unsafe {
-			return match sctp_sys::sctp_sendmsg(self.0, msg.as_ptr() as *const libc::c_void, len, raw_addr, addr_len, ppid, 0, stream, ttl, 0) {
+			return match sctp_sys::sctp_sendmsg(self.0, msg.as_ptr() as *const libc::c_void, len, raw_addr, addr_len, ppid as libc::c_ulong, 0, stream, ttl, 0) {
 				res if res > 0 => Ok(res as usize),
 				_ => Err(Error::last_os_error())
 			};

--- a/src/sctpsock.rs
+++ b/src/sctpsock.rs
@@ -358,7 +358,7 @@ impl SctpSocket {
 
 	/// Send data in Sctp style, to the provided address (may be `None` if the socket is connected), on the stream `stream`, with the TTL `ttl`.
 	/// On success, returns the quantity on bytes sent
-	pub fn sendmsg<A: ToSocketAddrs>(&self, msg: &[u8], address: Option<A>, stream: u16, ttl: libc::c_ulong) -> Result<usize> {
+	pub fn sendmsg<A: ToSocketAddrs>(&self, msg: &[u8], address: Option<A>, ppid: u64, stream: u16, ttl: libc::c_ulong) -> Result<usize> {
 		let len = msg.len() as libc::size_t;
 		let (raw_addr, addr_len) = match address {
 			Some(a) => {
@@ -368,7 +368,7 @@ impl SctpSocket {
 			None => (std::ptr::null_mut(), 0)
 		};
 		unsafe {
-			return match sctp_sys::sctp_sendmsg(self.0, msg.as_ptr() as *const libc::c_void, len, raw_addr, addr_len, 0, 0, stream, ttl, 0) {
+			return match sctp_sys::sctp_sendmsg(self.0, msg.as_ptr() as *const libc::c_void, len, raw_addr, addr_len, ppid, 0, stream, ttl, 0) {
 				res if res > 0 => Ok(res as usize),
 				_ => Err(Error::last_os_error())
 			};


### PR DESCRIPTION
In 5GCore (mobile backhaul), protocol called NGAP uses SCTP.  Specification says for NGAP SCTP's PPID should be 60.  With this PR, the PPID value can be specified in API.